### PR TITLE
Forgotten password cleanup

### DIFF
--- a/lib/email.ex
+++ b/lib/email.ex
@@ -4,8 +4,8 @@ defmodule Skillswheel.Email do
   def forgotten_password_email(email_address, rand_string) do
     new_email()
       |> to(email_address)
-      |> from("shouston3@me.com")
+      |> from("inclusiveclassroomstest@gmail.com")
       |> subject("Welcome!")
-      |> text_body("Please visit /forgotpass/" <> rand_string)
+      |> text_body("Please visit https://skillswheel.herokuapp.com/forgotpass/" <> rand_string)
   end
 end

--- a/lib/skillswheel/redis_client.ex
+++ b/lib/skillswheel/redis_client.ex
@@ -5,8 +5,9 @@ defmodule Skillswheel.RedisCli do
 
   def query(param), do: Redix.command(:redix, param)
 
-  def get(param), do: query(["get", param])
-  def set(param1, param2), do: query(["set", param1, param2])
+  def get(key), do: query(["get", key])
+  def set(key, value), do: query(["set", key, value])
+  def expire(key, seconds), do: query(["expire", key, seconds])
   def flushdb do
     query(["flushdb"])
     :ok

--- a/test/controllers/forgotpass_controller_test.exs
+++ b/test/controllers/forgotpass_controller_test.exs
@@ -64,8 +64,8 @@ defmodule Skillswheel.ForgotpassControllerTest do
       conn = post conn, forgotpass_path(conn, :update_password, "s00Rand0m"),
         %{"hash" => "s00Rand0m", "newpass" => %{"password" => "short"}}
 
-      assert redirected_to(conn, 302) =~ "/users"
-      assert get_flash(conn, :error) == "Invalid password"
+      assert redirected_to(conn, 302) =~ "/forgotpass/s00Rand0m"
+      assert get_flash(conn, :error) == "Invalid, ensure your password is 6-20 characters"
 
       user = Repo.get_by(User, email: "me@me.com")
 
@@ -85,7 +85,7 @@ defmodule Skillswheel.ForgotpassControllerTest do
         %{"hash" => "s00Rand0m", "newpass" => %{"password" => "short"}}
 
       assert redirected_to(conn, 302) =~ "/users"
-      assert get_flash(conn, :error) == "User not in Postgres"
+      assert get_flash(conn, :error) == "User has not been registered"
 
       assert Repo.get_by(User, email: "me@me.com") == nil
     end
@@ -102,7 +102,7 @@ defmodule Skillswheel.ForgotpassControllerTest do
         %{"hash" => "s00Rand0m", "newpass" => %{"password" => "mypass"}}
 
       assert redirected_to(conn, 302) =~ "/users"
-      assert get_flash(conn, :error) == "User not in Redis"
+      assert get_flash(conn, :error) == "The email link has expired"
 
       user = Repo.get_by(User, email: "me@me.com")
 
@@ -115,7 +115,7 @@ defmodule Skillswheel.ForgotpassControllerTest do
         %{"hash" => "s00Rand0m", "newpass" => %{"password" => "mypass"}}
 
       assert redirected_to(conn, 302) =~ "/users"
-      assert get_flash(conn, :error) == "User not in Redis"
+      assert get_flash(conn, :error) == "The email link has expired"
     end
 
     test "unregistered user with correct suffix", %{conn: conn}do
@@ -128,7 +128,7 @@ defmodule Skillswheel.ForgotpassControllerTest do
         %{"hash" => "s00Rand0m", "newpass" => %{"password" => "mypass"}}
 
       assert redirected_to(conn, 302) =~ "/users"
-      assert get_flash(conn, :error) == "User not in Redis"
+      assert get_flash(conn, :error) == "The email link has expired"
     end
   end
 
@@ -139,7 +139,7 @@ defmodule Skillswheel.ForgotpassControllerTest do
 
     test "user not found in redis" do
       actual = ForgotpassController.get_email_from_hash("s00Rand0m")
-      expected = {:error, "User not in Redis"}
+      expected = {:error, "The email link has expired"}
 
       assert actual == expected
     end
@@ -169,7 +169,7 @@ defmodule Skillswheel.ForgotpassControllerTest do
         email_suffix: "me.com"
       } |> Repo.insert
       actual = ForgotpassController.get_user_from_email({:ok, "me@me.com"})
-      expected = {:error, "User not in Postgres"}
+      expected = {:error, "User has not been registered"}
 
       assert actual == expected
     end

--- a/test/controllers/forgotpass_controller_test.exs
+++ b/test/controllers/forgotpass_controller_test.exs
@@ -43,7 +43,7 @@ defmodule Skillswheel.ForgotpassControllerTest do
       conn = post conn, forgotpass_path(conn, :update_password, "s00Rand0m"),
         %{"hash" => "s00Rand0m", "newpass" => %{"password" => "mypass"}}
 
-      assert redirected_to(conn, 302) =~ "/users"
+      assert redirected_to(conn, 302) =~ "/groups"
       assert get_flash(conn, :info) == "Password Changed"
 
       user = Repo.get_by(User, email: "me@me.com")

--- a/test/controllers/forgotpass_controller_test.exs
+++ b/test/controllers/forgotpass_controller_test.exs
@@ -41,10 +41,7 @@ defmodule Skillswheel.ForgotpassControllerTest do
       RedisCli.set("s00Rand0m", "me@me.com")
 
       conn = post conn, forgotpass_path(conn, :update_password, "s00Rand0m"),
-        %{"forgotpass" => %{
-          "hash" => "s00Rand0m",
-          "newpass" => %{"password" => "mypass"}
-        }}
+        %{"hash" => "s00Rand0m", "newpass" => %{"password" => "mypass"}}
 
       assert redirected_to(conn, 302) =~ "/users"
       assert get_flash(conn, :info) == "Password Changed"
@@ -65,10 +62,7 @@ defmodule Skillswheel.ForgotpassControllerTest do
       RedisCli.set("s00Rand0m", "me@me.com")
 
       conn = post conn, forgotpass_path(conn, :update_password, "s00Rand0m"),
-        %{"forgotpass" => %{
-          "hash" => "s00Rand0m",
-          "newpass" => %{"password" => "short"}
-        }}
+        %{"hash" => "s00Rand0m", "newpass" => %{"password" => "short"}}
 
       assert redirected_to(conn, 302) =~ "/users"
       assert get_flash(conn, :error) == "should be at least %{count} character(s)"

--- a/web/controllers/forgotpass_controller.ex
+++ b/web/controllers/forgotpass_controller.ex
@@ -1,6 +1,5 @@
 defmodule Skillswheel.ForgotpassController do
   use Skillswheel.Web, :controller
-  require IEx
 
   alias Skillswheel.{User, RedisCli, Auth}
   alias Ecto.Changeset
@@ -12,7 +11,7 @@ defmodule Skillswheel.ForgotpassController do
   def create(conn, %{"forgotpass" => %{"email" => email}}) do
     rand_string = gen_rand_string(30)
 
-    RedisCli.query(["SET", rand_string, email])
+    RedisCli.set(rand_string, email)
 
     email
     |> Skillswheel.Email.forgotten_password_email(rand_string)
@@ -33,7 +32,7 @@ defmodule Skillswheel.ForgotpassController do
     |> redirect(to: path.(conn, :new))
   end
 
-  def update_password(conn, %{"forgotpass" => %{"hash" => hash, "newpass" => %{"password" => password}}}) do
+  def update_password(conn, %{"hash" => hash, "newpass" => %{"password" => password}}) do
     update
       =  get_email_from_hash(hash)
       |> get_user_from_email()

--- a/web/controllers/forgotpass_controller.ex
+++ b/web/controllers/forgotpass_controller.ex
@@ -10,8 +10,10 @@ defmodule Skillswheel.ForgotpassController do
 
   def create(conn, %{"forgotpass" => %{"email" => email}}) do
     rand_string = gen_rand_string(30)
+    one_day = 24 * 60 * 60
 
     RedisCli.set(rand_string, email)
+    RedisCli.expire(rand_string, one_day)
 
     email
     |> Skillswheel.Email.forgotten_password_email(rand_string)

--- a/web/controllers/forgotpass_controller.ex
+++ b/web/controllers/forgotpass_controller.ex
@@ -90,7 +90,7 @@ defmodule Skillswheel.ForgotpassController do
         conn
         |> Auth.login(user)
         |> put_flash(:info, "Password Changed")
-        |> redirect(to: user_path(conn, :index))
+        |> redirect(to: group_path(conn, :index))
       {:error, message} ->
         case message do
           "invalid_pass" ->

--- a/web/controllers/forgotpass_controller.ex
+++ b/web/controllers/forgotpass_controller.ex
@@ -73,7 +73,6 @@ defmodule Skillswheel.ForgotpassController do
 
   def validate_password(tuple, password) do
     case tuple do
-      {:ok, nil} -> {:error, "NIL"}
       {:ok, user} ->
         params = %{
           "email" => user.email,
@@ -82,10 +81,8 @@ defmodule Skillswheel.ForgotpassController do
         }
         changeset = User.validate_password(%User{}, params)
         cond do
-          changeset.valid? ->
-            {:ok, changeset}
-          true ->
-            {:error, elem(elem(hd(changeset.errors), 1), 0)}
+          changeset.valid? -> {:ok, changeset}
+          true -> {:error, "Invalid password"}
         end
       {:error, struct} -> {:error, struct}
     end

--- a/web/controllers/forgotpass_controller.ex
+++ b/web/controllers/forgotpass_controller.ex
@@ -1,4 +1,41 @@
 defmodule Skillswheel.ForgotpassController do
+  @moduledoc """
+  # Forgotten Password
+
+  ### Views:
+  * index
+  Where a user can send an email to their email address
+  This will send a link for them to reset their password with
+  * show
+  Where a user can reset their password
+  ### Endpoints
+  * create
+  The endpoint for recieving the form from `index`
+  - Generates a random hash
+  - Stores this temporary hash in redis
+  - Sends a link to the user corresponding to this hash
+  * update_password
+  The endpoint for recievign the form from `show`
+  - Validates incoming hash
+  - Fetches user from postgres
+  - Validates password
+  - Replaces old password with new one
+
+  ### How to manual test
+  * Log in as admin
+  * Go to `/admin`
+  * Ensure that your email suffix is registered
+  * Log out
+  * Try forgotten password flow:
+  - with an unregistered domain
+  - with a non registered user, but registered domain
+  - with an incorrect hash
+  - check that the users you have been trying with don't exist in the database
+  - with a properly registered user
+  - check that the new password works
+  - check that the old password doesnt
+  """
+
   use Skillswheel.Web, :controller
 
   alias Skillswheel.{User, RedisCli, Auth}

--- a/web/router.ex
+++ b/web/router.ex
@@ -18,7 +18,7 @@ defmodule Skillswheel.Router do
     pipe_through :browser # Use the default browser stack
 
     get "/", PageController, :index
-    resources "/users", UserController, only: [:index, :new, :create]
+    resources "/users", UserController, only: [:new, :create]
     resources "/sessions", SessionController, only: [:new, :create, :delete]
     resources "/admin", AdminController, only: [:index]
     resources "/school", SchoolController, only: [:create, :delete]

--- a/web/templates/forgotpass/reset.html.eex
+++ b/web/templates/forgotpass/reset.html.eex
@@ -3,7 +3,7 @@
 <%= form_for @conn, forgotpass_path(@conn, :update_password, @hash), [as: :newpass], fn f -> %>
   <h6>Please enter your new password:</h6>
   <div class="form-group">
-    <%= label f, :email, class: "control-label" %>
+    <%= label f, :new_password, class: "control-label" %>
     <%= password_input f, :password, class: "form-control" %>
   </div>
   <%= submit "Send", class: "btn btn-primary" %>


### PR DESCRIPTION
Merge after #76 

- [x] Now sending from the inclusive classroom email address instead of from mine
- [x] Adding further tests for main `forgotten_password` function
- [x] Fixing mistake for how we were receiving the form from the front end in the controller
- [x] Altering the tests accordingly
- [x] Unit testing smaller functions
- [x] Ensuring all the redirections are correct

@jackcarlisle Ready to go

Let me know if you can break anything in the flow
Make note of any redirections or messages that should be different

Check out the manual testing documentation here: https://github.com/InclusiveClassrooms/skills-wheel/pull/78/files#diff-472439535deb184ba5c8a9250605e0d6R24

Note there is still prettifying of email sent, etc which will be done here: https://github.com/InclusiveClassrooms/skills-wheel/issues/73