### PR TITLE
Refactor

### DIFF
--- a/test/controllers/admin_controller_test.exs
+++ b/test/controllers/admin_controller_test.exs
@@ -27,7 +27,6 @@ defmodule Skillswheel.AdminControllerTest do
     end
   end
 
-
   describe "admin unauthorised" do
     setup do
       admin_auth(false)

--- a/test/controllers/auth_test.exs
+++ b/test/controllers/auth_test.exs
@@ -1,100 +1,87 @@
 defmodule Skillswheel.AuthTest do
   use Skillswheel.ConnCase, async: false
 
-  alias Skillswheel.{Auth, School, Router, User}
+  alias Skillswheel.{Auth, Router, User}
 
-  setup %{conn: conn} do
-    %School{
-      id: 1,
-      name: "Test School",
-      email_suffix: "test.com"
-    } |> Repo.insert
+  describe "auth controller" do
+    setup %{conn: conn} do
+      insert_school()
 
-    conn =
-      conn
-      |> bypass_through(Router, :browser)
-      |> get("/")
-    {:ok, %{conn: conn}}
-  end
+      conn =
+        conn
+        |> bypass_through(Router, :browser)
+        |> get("/")
 
-  test "testing init function" do
-    assert Auth.init([repo: 1])
-  end
+      {:ok, %{conn: conn}}
+    end
 
-  test "authenticate_user halts when no current_user exists", %{conn: conn} do
-    conn = Auth.authenticate_user(conn, [])
-    assert conn.halted
-  end
+    test "testing init function", do: assert Auth.init([repo: 1])
 
-  test "authenticate_user continues when the current_user exists", %{conn: conn} do
-    conn =
-      conn
-      |> assign(:current_user, %User{})
-      |> Auth.authenticate_user([])
-    refute conn.halted
-  end
+    test "authenticate_user halts when no current_user exists", %{conn: conn} do
+      conn = Auth.authenticate_user(conn, [])
+      assert conn.halted
+    end
 
-  test "login puts the user in the session", %{conn: conn} do
-    login_conn =
-      conn
-      |> Auth.login(%User{id: 123})
-      |> send_resp(:ok, "")
-    next_conn = get(login_conn, "/")
-    assert get_session(next_conn, :user_id) == 123
-  end
+    test "authenticate_user continues when the current_user exists", %{conn: conn} do
+      conn =
+        conn
+        |> assign(:current_user, %User{})
+        |> Auth.authenticate_user([])
+      refute conn.halted
+    end
 
-  test "logout drops the session", %{conn: conn} do
-    logout_conn =
-      conn
-      |> put_session(:user_id, 123)
-      |> Auth.logout()
-      |> send_resp(:ok, "")
+    test "login puts the user in the session", %{conn: conn} do
+      login_conn =
+        conn
+        |> Auth.login(%User{id: 123})
+        |> send_resp(:ok, "")
+      next_conn = get(login_conn, "/")
+      assert get_session(next_conn, :user_id) == 123
+    end
 
-    next_conn = get(logout_conn, "/")
-    refute get_session(next_conn, :user_id)
-  end
+    test "logout drops the session", %{conn: conn} do
+      logout_conn =
+        conn
+        |> put_session(:user_id, 123)
+        |> Auth.logout()
+        |> send_resp(:ok, "")
 
-  test "call places user from session into assigns", %{conn: conn} do
-    user = insert_user()
-    conn =
-      conn
-      |> put_session(:user_id, user.id)
-      |> Auth.call(Repo)
+      next_conn = get(logout_conn, "/")
+      refute get_session(next_conn, :user_id)
+    end
 
-    assert conn.assigns.current_user.id == user.id
-  end
+    test "call places user from session into assigns", %{conn: conn} do
+      user = insert_user()
+      conn =
+        conn
+        |> put_session(:user_id, user.id)
+        |> Auth.call(Repo)
 
-  test "call with no session sets current_user assign to nil", %{conn: conn} do
-    conn = Auth.call(conn, Repo)
-    assert conn.assigns.current_user == nil
-  end
+      assert conn.assigns.current_user.id == user.id
+    end
 
-  test "login with a valid username and pass", %{conn: conn} do
-    %School{
-      id: 2,
-      name: "Test Schools",
-      email_suffix: "test2.com"
-    } |> Repo.insert
-    user = insert_user(%{email: "me@test2.com", password: "secret", school_id: 2})
-    {:ok, conn} =
-      Auth.login_by_email_and_pass(conn, "me@test2.com", "secret", repo: Repo)
+    test "call with no session sets current_user assign to nil", %{conn: conn} do
+      conn = Auth.call(conn, Repo)
+      assert conn.assigns.current_user == nil
+    end
 
-    assert conn.assigns.current_user.id == user.id
-  end
+    test "login with a valid username and pass", %{conn: conn} do
+      user = insert_user(%{email: "me@test.com", password: "secret", school_id: 1})
+      {:ok, conn} =
+        Auth.login_by_email_and_pass(conn, "me@test.com", "secret", repo: Repo)
 
-  test "login with a not found user", %{conn: conn} do
-    assert {:error, :not_found, _conn} =
-      Auth.login_by_email_and_pass(conn, "me@me.com", "secret", repo: Repo)
-  end
+      assert conn.assigns.current_user.id == user.id
+    end
 
-  test "login with password mismatch", %{conn: conn} do
-    %School{
-      id: 3,
-      name: "Test School2",
-      email_suffix: "test2.com"
-    } |> Repo.insert
-    _ = insert_user(%{email: "me@test2.com", password: "secret"})
-    assert {:error, :unauthorized, _conn} =
-      Auth.login_by_email_and_pass(conn, "me@test2.com", "wrong", repo: Repo)
+    test "login with a not found user", %{conn: conn} do
+      assert {:error, :not_found, _conn} =
+        Auth.login_by_email_and_pass(conn, "me@me.com", "secret", repo: Repo)
+    end
+
+    test "login with password mismatch", %{conn: conn} do
+      insert_user(%{email: "me@test.com", password: "secret"})
+      assert {:error, :unauthorized, _conn} =
+        Auth.login_by_email_and_pass(conn, "me@test.com", "wrong", repo: Repo)
+    end
   end
 end

--- a/test/controllers/group_controller_test.exs
+++ b/test/controllers/group_controller_test.exs
@@ -18,8 +18,6 @@ defmodule Skillswheel.GroupControllerTest do
     else
       :ok
     end
-
-
   end
 
   describe "group paths with authentication" do

--- a/test/models/student_test.exs
+++ b/test/models/student_test.exs
@@ -18,7 +18,14 @@ defmodule Skillswheel.StudentTest do
      year_group: "4",
      group_id: 7
    }
-   @invalid_attrs %{first_name: "", last_name: "", sex: "", year_group: "", group_id: ""}
+
+   @invalid_attrs %{
+    first_name: "",
+    last_name: "",
+    sex: "",
+    year_group: "",
+    group_id: ""
+  }
 
    test "changeset with valid attributes" do
      changeset = Student.changeset(%Student{}, @valid_attrs)

--- a/test/support/test_helpers.ex
+++ b/test/support/test_helpers.ex
@@ -1,5 +1,5 @@
 defmodule Skillswheel.TestHelpers do
-  alias Skillswheel.Repo
+  alias Skillswheel.{Repo, User, School}
 
   def insert_user(attrs \\ %{}) do
     changes = Map.merge(%{
@@ -9,8 +9,16 @@ defmodule Skillswheel.TestHelpers do
       school_id: 1
     }, attrs)
 
-    %Skillswheel.User{}
-    |> Skillswheel.User.registration_changeset(changes)
+    %User{}
+    |> User.registration_changeset(changes)
     |> Repo.insert!()
+  end
+
+  def insert_school() do
+    %School{
+      id: 1,
+      name: "Test School",
+      email_suffix: "test.com"
+    } |> Repo.insert
   end
 end


### PR DESCRIPTION
Wraps the auth controller in a describe with a single setup and no further school insertions

Ensuring consistent use of test helpers

Implementing an `insert_school` helper

Handling errors in one function and use everywhere instead of error handling in every function and changing tests accordingly

Fixes #84 